### PR TITLE
Don't clear $FLAGS and rename to $ELECTRON_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Flatpak build of [Arduino IDE 2.x](https://github.com/arduino/arduino-ide). To run the
 app you need USB permissions, preferably, the user has to be part of the
-`dialout` group. Alternatively, add
+`dialout` group. Alternatively, add:
 ``` sh
 KERNEL=="ttyUSB[0-9]*",MODE="0666"
 KERNEL=="ttyACM[0-9]*",MODE="0666"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Flatpak build of [Arduino IDE 2.x](https://github.com/arduino/arduino-ide). To run the
 app you need USB permissions, preferably, the user has to be part of the
-`dialout` group. Alternatively, add 
+`dialout` group. Alternatively, add
 ``` sh
 KERNEL=="ttyUSB[0-9]*",MODE="0666"
 KERNEL=="ttyACM[0-9]*",MODE="0666"
@@ -19,3 +19,7 @@ Any arguments passed to the flatpak run command will be passed to the IDE i.e.
 flatpak run cc.arduino.IDE2 --log-level=warn
 ```
 which only displays warning or above in the log output to the console.
+If you like to pass certain flags permanently, you can add them to the `ELECTRON_FLAGS` environment variable:
+``` sh
+flatpak override --user --env=ELECTRON_FLAGS="--log-level=warn" cc.arduino.IDE2
+```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ Any arguments passed to the flatpak run command will be passed to the IDE i.e.
 flatpak run cc.arduino.IDE2 --log-level=warn
 ```
 which only displays warning or above in the log output to the console.
-If you like to pass certain flags permanently, you can add them to the `ELECTRON_FLAGS` environment variable:
+
+## Adding permanent custom flags to the IDE
+If you need to always start the IDE with custom arguments then the best way to do this is to use `flatpak override`.
+For example:
 ``` sh
-flatpak override --user --env=ELECTRON_FLAGS="--log-level=warn" cc.arduino.IDE2
+flatpak override --user --env=CUSTOM_IDE_FLAGS="--log-level=warn" cc.arduino.IDE2
 ```
+This is also useful if you want to enable electron's (potentially experimental) wayland support:
+``` sh
+flatpak override --user --socket=wayland cc.arduino.IDE2
+flatpak override --user --env=CUSTOM_IDE_FLAGS="--enable-features=UseOzonePlatform --ozone-platform=wayland" cc.arduino.IDE2
+```
+It is important to note that if you are experiencing issues with the IDE you MUST turn this off before submitting a bug report here or on the IDE's bug tracker as this functionality is not functionality supported.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ This is also useful if you want to enable electron's (potentially experimental) 
 flatpak override --user --socket=wayland cc.arduino.IDE2
 flatpak override --user --env=CUSTOM_IDE_FLAGS="--enable-features=UseOzonePlatform --ozone-platform=wayland" cc.arduino.IDE2
 ```
-It is important to note that if you are experiencing issues with the IDE you MUST turn this off before submitting a bug report here or on the IDE's bug tracker as this functionality is not functionality supported.
+It is important to note that if you are experiencing issues with the IDE you MUST disable any custom flags you have before submitting a bug report here or on the IDE's bug tracker as this functionality is not officially supported.

--- a/arduino-ide.sh
+++ b/arduino-ide.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-FLAGS=''
-
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
-    FLAGS="$FLAGS --disable-gpu-sandbox"
+    ELECTRON_FLAGS="$ELECTRON_FLAGS --disable-gpu-sandbox"
 fi
 
 # I cracked zypak's secrets
 export ZYPAK_SPAWN_LATEST_ON_REEXEC=0
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/arduino-ide/arduino-ide /app/arduino-ide/resources/app/scripts/arduino-ide-electron-main.js $FLAGS "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/arduino-ide/arduino-ide /app/arduino-ide/resources/app/scripts/arduino-ide-electron-main.js $ELECTRON_FLAGS "$@"

--- a/arduino-ide.sh
+++ b/arduino-ide.sh
@@ -2,9 +2,9 @@
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
-    ELECTRON_FLAGS="$ELECTRON_FLAGS --disable-gpu-sandbox"
+    CUSTOM_IDE_FLAGS="$CUSTOM_IDE_FLAGS --disable-gpu-sandbox"
 fi
 
 # I cracked zypak's secrets
 export ZYPAK_SPAWN_LATEST_ON_REEXEC=0
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/arduino-ide/arduino-ide /app/arduino-ide/resources/app/scripts/arduino-ide-electron-main.js $ELECTRON_FLAGS "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/arduino-ide/arduino-ide /app/arduino-ide/resources/app/scripts/arduino-ide-electron-main.js $CUSTOM_IDE_FLAGS "$@"


### PR DESCRIPTION
That way `$ELECTRON_FLAGS` can be passed to the IDE. Corresponding README section added.

(Also removes one trailing whitespace in README.md).