### PR TITLE
Add adafruit-nrfutil binary to the flatpak so the Adafruit nRF52 libraries will work with the IDE

### DIFF
--- a/cc.arduino.IDE2.json
+++ b/cc.arduino.IDE2.json
@@ -131,7 +131,7 @@
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "pyserial",
-                        "packagetype": "source"
+                        "packagetype": "sdist"
                     }
                 }
             ]

--- a/cc.arduino.IDE2.json
+++ b/cc.arduino.IDE2.json
@@ -80,6 +80,63 @@
             ]
         },
         {
+            "name": "python3-click",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"click\""
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl",
+                    "sha256": "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyserial",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-ecdsa",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"ecdsa\""
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/09/d4/4f05f5d16a4863b30ba96c23b23e942da8889abfa1cdbabf2a0df12a4532/ecdsa-0.18.0-py2.py3-none-any.whl",
+                    "sha256": "80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyserial",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-adafruit-nrfutil",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"adafruit-nrfutil\""
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/dc/4fed50ed2192fa5d5b3b2f43c50a629e56fa99198131de6c86a50164a66f/adafruit-nrfutil-0.5.3.post16.tar.gz",
+                    "sha256": "b72103dc8e50f92951f512fc2b6f2c621dac1614531ddf8c0be3b13d020e24ad",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyserial",
+                        "packagetype": "source"
+                    }
+                }
+            ]
+        },
+        {
             "name": "git",
             "make-args": [
                 "NO_TCLTK=1",


### PR DESCRIPTION
This adds the adafruit-nrfutil binary to the flatpak image so once `https://adafruit.github.io/arduino-board-index/package_adafruit_index.json` is added as an additional board and the `Adafruit nRF52 by Adafruit` board is installed it will work with the IDE.

This also means that the step of installing the tool by pip (`pip3 install --user adafruit-nrfutil`) is not required by flatpak users.