### PR TITLE
Remove org.freedesktop.Notifications bus access

### DIFF
--- a/cc.arduino.IDE2.json
+++ b/cc.arduino.IDE2.json
@@ -16,8 +16,7 @@
         "--filesystem=home",
         "--filesystem=xdg-run/keyring",
         "--system-talk-name=org.gtk.vfs.*",
-        "--talk-name=org.freedesktop.secrets",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.secrets"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",


### PR DESCRIPTION
The electron baseapp has libnotify 0.8 which uses the portal for notifications, so this is no longer required

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25